### PR TITLE
Fixed crash when unloading module

### DIFF
--- a/source/stringtable.cpp
+++ b/source/stringtable.cpp
@@ -548,8 +548,6 @@ void Deinitialize( lua_State *state )
 			Destroy( state, -1 );
 			LUA->Pop( 1 );
 		}
-
-		LUA->Pop( 1 );
 	}
 
 	LUA->Pop( 1 );


### PR DESCRIPTION
Unnecessary LUA->Pop() crashes lua_shared.dll